### PR TITLE
 Support for pepper version 47

### DIFF
--- a/examples/ppapi_cpp/Makefile
+++ b/examples/ppapi_cpp/Makefile
@@ -34,6 +34,9 @@ TARGET=ppapi_cpp
 AT_LEAST_33:=$(shell $(GETOS) --check-version=33 2>&1)
 AT_LEAST_34:=$(shell $(GETOS) --check-version=34 2>&1)
 AT_LEAST_35:=$(shell $(GETOS) --check-version=35 2>&1)
+AT_LEAST_36:=$(shell $(GETOS) --check-version=36 2>&1)
+AT_LEAST_37:=$(shell $(GETOS) --check-version=37 2>&1)
+AT_LEAST_38:=$(shell $(GETOS) --check-version=38 2>&1)
 
 SOURCES = \
   array_output.cc \
@@ -75,7 +78,6 @@ SOURCES = \
   scriptable_object_deprecated.cc \
   selection_dev.cc \
   simple_thread.cc \
-  socket_dev.cc \
   tcp_socket.cc \
   text_input_controller.cc \
   truetype_font_dev.cc \
@@ -107,9 +109,7 @@ endif
 ifeq ($(AT_LEAST_34),)
 # 34 and up
 SOURCES += \
-  alarms_dev.cc \
   media_stream_video_track.cc \
-  string_wrapper_dev.cc \
   video_frame.cc \
 
 else
@@ -134,6 +134,34 @@ SOURCES += \
   graphics_2d_dev.cc \
   ime_input_event_dev.cc \
   scrollbar_dev.cc \
+  text_input_dev.cc \
+  url_util_dev.cc \
+  video_capture_client_dev.cc \
+  video_capture_dev.cc \
+  video_decoder_client_dev.cc \
+  video_decoder_dev.cc \
+  widget_client_dev.cc \
+  widget_dev.cc \
+
+endif
+
+ifeq ($(AT_LEAST_36),)
+# 36 and up
+
+else
+# Before 36
+SOURCES += \
+  alarms_dev.cc \
+  audio_input_dev.cc \
+  buffer_dev.cc \
+  crypto_dev.cc \
+  device_ref_dev.cc \
+  find_dev.cc \
+  graphics_2d_dev.cc \
+  ime_input_event_dev.cc \
+  scrollbar_dev.cc \
+  socket_dev.cc \
+  string_wrapper_dev.cc \
   text_input_dev.cc \
   url_util_dev.cc \
   video_capture_client_dev.cc \

--- a/examples/ppapi_cpp/Makefile
+++ b/examples/ppapi_cpp/Makefile
@@ -35,8 +35,8 @@ AT_LEAST_33:=$(shell $(GETOS) --check-version=33 2>&1)
 AT_LEAST_34:=$(shell $(GETOS) --check-version=34 2>&1)
 AT_LEAST_35:=$(shell $(GETOS) --check-version=35 2>&1)
 AT_LEAST_36:=$(shell $(GETOS) --check-version=36 2>&1)
-AT_LEAST_37:=$(shell $(GETOS) --check-version=37 2>&1)
-AT_LEAST_38:=$(shell $(GETOS) --check-version=38 2>&1)
+# Versions between 36 and 47 have not been tested
+AT_LEAST_47:=$(shell $(GETOS) --check-version=47 2>&1)
 
 SOURCES = \
   array_output.cc \
@@ -76,7 +76,6 @@ SOURCES = \
   rect.cc \
   resource.cc \
   scriptable_object_deprecated.cc \
-  selection_dev.cc \
   simple_thread.cc \
   tcp_socket.cc \
   text_input_controller.cc \
@@ -93,7 +92,6 @@ SOURCES = \
   view_dev.cc \
   websocket.cc \
   websocket_api.cc \
-  zoom_dev.cc \
 
 ifeq ($(AT_LEAST_33),)
 # 33 and up
@@ -170,6 +168,27 @@ SOURCES += \
   video_decoder_dev.cc \
   widget_client_dev.cc \
   widget_dev.cc \
+
+endif
+
+ifeq ($(AT_LEAST_47),)
+# 47 and up
+SOURCES += \
+  audio_buffer.cc \
+  audio_encoder.cc \
+  compositor.cc \
+  compositor_layer.cc \
+  media_stream_audio_track.cc \
+  media_stream_video_track.cc \
+  video_decoder.cc \
+  video_encoder.cc \
+  video_frame.cc \
+  
+else
+# Before 47
+SOURCES += \
+  selection_dev.cc \
+  zoom_dev.cc \
 
 endif
 

--- a/ppapi_preamble.js
+++ b/ppapi_preamble.js
@@ -299,7 +299,7 @@ var createInterface = function(name, functions) {
 var Module = {
   "noInitialRun": true,
   "noExitRuntime": true,
-  "preInit": function() {
+  "onRuntimeInitialized": function() {
     for (var i = 0; i < declaredInterfaces.length; i++) {
       var inf = declaredInterfaces[i];
       if (inf.supported === undefined || inf.supported()) {

--- a/tools/nacl_emscripten.mk
+++ b/tools/nacl_emscripten.mk
@@ -29,8 +29,8 @@ EM_LIB?="$(EMSCRIPTEN)/emar"
 endif
 
 # Architecture-specific flags
-EM_CFLAGS?=-DNACL_ARCH=x86_32 -Wno-warn-absolute-paths
-EM_CXXFLAGS?=-DNACL_ARCH=x86_32 -Wno-warn-absolute-paths
+EM_CFLAGS?=-DNACL_ARCH=x86_32
+EM_CXXFLAGS?=-DNACL_ARCH=x86_32
 
 NACL_CFLAGS?=-Wno-long-long -Werror
 NACL_CXXFLAGS?=-Wno-long-long -Werror


### PR DESCRIPTION
Some files have been added and removed between version 38 and 47.
ppapi_cpp/Makefile has been changed so that it works with version 47.
The warning flag about absolute paths has been removed in Emscripten.
Update nacl_emscripten.mk to take this into account.
Emscripten doesn't allow pepper interfaces to be created in preInit.
Update ppapi_preamble.js to do this in onRuntimeInitialized instead.
